### PR TITLE
Update vpa108csulzh.cpp (CVE-2015-2278) - memset v array

### DIFF
--- a/pysapcompress/vpa108csulzh.cpp
+++ b/pysapcompress/vpa108csulzh.cpp
@@ -213,6 +213,10 @@ int CsObjectInt::BuildHufTree (
 
   /* Generate counts for each bit length .............................*/
   memset(c, 0, sizeof(c));
+  memset(u, 0, sizeof(u));
+  memset(v, 0, sizeof(v));
+  memset(x, 0, sizeof(x));
+  
   p = b;  i = n;
   do
   {


### PR DESCRIPTION
Hi, this is patch what fix reason of CVE-2015-2278. Commit 4182281 did not fix root of problem (CVE-2015-2278) - v array not initialized.