### PR TITLE
Port SAPCAR layer to be Python 2/3 compatible

### DIFF
--- a/pysap/SAPCAR.py
+++ b/pysap/SAPCAR.py
@@ -710,7 +710,10 @@ class SAPCARArchive(object):
         :return: list of file names
         :rtype: list(six.text_type)
         """
-        return self.files.keys()
+        if six.PY2:
+            return self.files.keys()
+        # In Python 3, dict.keys() returns fancy new dict_keys object that needs type conversion
+        return list(self.files.keys())
 
     @property
     def version(self):

--- a/pysap/SAPCAR.py
+++ b/pysap/SAPCAR.py
@@ -524,7 +524,7 @@ class SAPCARArchiveFile(object):
         """
 
         # Read the file properties and its content
-        stat = os_stat(filename)
+        fil_stat = os_stat(filename)
         with open(filename, "rb") as fd:
             data = fd.read()
 
@@ -547,9 +547,9 @@ class SAPCARArchiveFile(object):
         # Build the object and fill the fields
         archive_file = cls()
         archive_file._file_format = ff()
-        archive_file._file_format.perm_mode = stat.st_mode
-        archive_file._file_format.timestamp = stat.st_atime
-        archive_file._file_format.file_length = stat.st_size
+        archive_file._file_format.perm_mode = fil_stat.st_mode
+        archive_file._file_format.timestamp = fil_stat.st_atime
+        archive_file._file_format.file_length = fil_stat.st_size
         archive_file._file_format.filename = archive_filename
         archive_file._file_format.filename_length = len(archive_filename)
         if archive_file._file_format.version == SAPCAR_VERSION_201:

--- a/pysap/SAPCAR.py
+++ b/pysap/SAPCAR.py
@@ -111,17 +111,17 @@ class SAPCARCompressedBlobFormat(PacketNoPadded):
     ]
 
 
+# SAP CAR compressed end of data block
 SAPCAR_BLOCK_TYPE_COMPRESSED_LAST = b"ED"
-"""SAP CAR compressed end of data block"""
 
+# SAP CAR compressed block
 SAPCAR_BLOCK_TYPE_COMPRESSED = b"DA"
-"""SAP CAR compressed block"""
 
+# SAP CAR uncompressed end of data block
 SAPCAR_BLOCK_TYPE_UNCOMPRESSED_LAST = b"UE"
-"""SAP CAR uncompressed end of data block"""
 
+# SAP CAR uncompressed block
 SAPCAR_BLOCK_TYPE_UNCOMPRESSED = b"UD"
-"""SAP CAR uncompressed block"""
 
 
 class SAPCARCompressedBlockFormat(PacketNoPadded):
@@ -152,27 +152,27 @@ def sapcar_is_last_block(packet):
     return packet.type in [SAPCAR_BLOCK_TYPE_COMPRESSED_LAST, SAPCAR_BLOCK_TYPE_UNCOMPRESSED_LAST]
 
 
+# SAP CAR regular file string
 SAPCAR_TYPE_FILE = b"RG"
-"""SAP CAR regular file string"""
 
+# SAP CAR directory string
 SAPCAR_TYPE_DIR = b"DR"
-"""SAP CAR directory string"""
 
+# SAP CAR Windows short cut string
 SAPCAR_TYPE_SHORTCUT = b"SC"
-"""SAP CAR Windows short cut string"""
 
+# SAP CAR Unix soft link string
 SAPCAR_TYPE_LINK = b"LK"
-"""SAP CAR Unix soft link string"""
 
+# SAP CAR AS400 save file string
 SAPCAR_TYPE_AS400 = b"SV"
-"""SAP CAR AS400 save file string"""
 
 # Version strings are unicode instead of byte strings in order to avoid constant .decode() and .encode() calls
+# SAP CAR file format version 2.00 string
 SAPCAR_VERSION_200 = "2.00"
-"""SAP CAR file format version 2.00 string"""
 
+# SAP CAR file format version 2.01 string
 SAPCAR_VERSION_201 = "2.01"
-"""SAP CAR file format version 2.01 string"""
 
 
 class SAPCARArchiveFilev200Format(PacketNoPadded):
@@ -281,18 +281,17 @@ class SAPCARArchiveFilev201Format(SAPCARArchiveFilev200Format):
     is_filename_null_terminated = True
 
 
+# SAP CAR archive header magic string standard
 SAPCAR_HEADER_MAGIC_STRING_STANDARD = b"CAR\x20"
-"""SAP CAR archive header magic string standard"""
 
+# SAP CAR archive header magic string backup file
 SAPCAR_HEADER_MAGIC_STRING_BACKUP = b"CAR\x00"
-"""SAP CAR archive header magic string backup file"""
 
-
+# SAP CAR file format versions
 sapcar_archive_file_versions = {
     SAPCAR_VERSION_200: SAPCARArchiveFilev200Format,
     SAPCAR_VERSION_201: SAPCARArchiveFilev201Format,
 }
-"""SAP CAR file format versions"""
 
 
 class SAPCARArchiveFormat(Packet):

--- a/pysap/SAPCAR.py
+++ b/pysap/SAPCAR.py
@@ -25,7 +25,7 @@ from zlib import crc32
 from struct import pack
 from datetime import datetime
 from os import stat as os_stat
-from cStringIO import StringIO
+from io import BytesIO
 # External imports
 from scapy.packet import Packet
 from scapy.fields import (ByteField, ByteEnumField, LEIntField, FieldLenField,
@@ -618,7 +618,7 @@ class SAPCARArchiveFile(object):
             raise Exception("Invalid file type")
 
         # Extract the file to a file-like object
-        out_file = StringIO()
+        out_file = BytesIO()
         checksum = self._file_format.extract(out_file)
         out_file.seek(0)
 

--- a/pysap/utils/six.py
+++ b/pysap/utils/six.py
@@ -1,0 +1,39 @@
+# ===========
+# pysap - Python library for crafting SAP's network protocols packets
+#
+# Copyright (C) 2012-2018 by Martin Gallo, Core Security
+#
+# The library was designed and developed by Martin Gallo from
+# Core Security's CoreLabs team.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# ==============
+
+# All custom general purpose Python 2/3 compatibility should go here
+
+from __future__ import absolute_import
+
+import six
+
+
+def unicode(string):
+    """
+    Convert given string to unicode string
+    :param string: String to convert
+    :type string: bytes | str | unicode
+    :return: six.text_type
+    """
+    string_type = type(string)
+    if string_type == six.binary_type:
+        return string.decode()
+    elif string_type == six.text_type:
+        return string
+    raise ValueError("Expected bytes or str, got {}".format(string_type))

--- a/tests/sapcar_test.py
+++ b/tests/sapcar_test.py
@@ -19,6 +19,7 @@
 
 # Standard imports
 from __future__ import unicode_literals
+import six
 import unittest
 from os import unlink, path
 # External imports
@@ -58,7 +59,10 @@ class PySAPCARTest(unittest.TestCase):
             self.assertEqual(1, len(sapcar_archive.files))
             self.assertEqual(1, len(sapcar_archive.files_names))
             self.assertListEqual([self.test_filename], sapcar_archive.files_names)
-            self.assertListEqual([self.test_filename], sapcar_archive.files.keys())
+            if six.PY2:
+                self.assertListEqual([self.test_filename], sapcar_archive.files.keys())
+            else:
+                self.assertListEqual([self.test_filename], list(sapcar_archive.files.keys()))
 
             af = sapcar_archive.open(self.test_filename)
             self.assertEqual(self.test_string, af.read())
@@ -109,7 +113,10 @@ class PySAPCARTest(unittest.TestCase):
         self.assertEqual(2, len(ar.files))
         self.assertEqual(2, len(ar.files_names))
         self.assertListEqual([self.test_filename, self.test_filename+"two"], ar.files_names)
-        self.assertListEqual([self.test_filename, self.test_filename+"two"], ar.files.keys())
+        if six.PY2:
+            self.assertListEqual([self.test_filename, self.test_filename+"two"], ar.files.keys())
+        else:
+            self.assertListEqual([self.test_filename, self.test_filename+"two"], list(ar.files.keys()))
 
         for filename in [self.test_filename, self.test_filename+"two"]:
             af = ar.open(filename)

--- a/tests/sapcar_test.py
+++ b/tests/sapcar_test.py
@@ -19,8 +19,7 @@
 
 # Standard imports
 import unittest
-from os import unlink
-from os.path import basename, exists
+from os import unlink, path
 # External imports
 # Custom imports
 from tests.utils import data_filename
@@ -44,7 +43,7 @@ class PySAPCARTest(unittest.TestCase):
 
     def tearDown(self):
         for filename in [self.test_filename, self.test_archive_file]:
-            if exists(filename):
+            if path.exists(filename):
                 unlink(filename)
 
     def check_sapcar_archive(self, filename, version):
@@ -53,7 +52,7 @@ class PySAPCARTest(unittest.TestCase):
         with open(data_filename(filename), "rb") as fd:
             sapcar_archive = SAPCARArchive(fd, mode="r")
 
-            self.assertEqual(filename, basename(sapcar_archive.filename))
+            self.assertEqual(filename, path.basename(sapcar_archive.filename))
             self.assertEqual(version, sapcar_archive.version)
             self.assertEqual(1, len(sapcar_archive.files))
             self.assertEqual(1, len(sapcar_archive.files_names))

--- a/tests/sapcar_test.py
+++ b/tests/sapcar_test.py
@@ -18,6 +18,7 @@
 # ==============
 
 # Standard imports
+from __future__ import unicode_literals
 import unittest
 from os import unlink, path
 # External imports
@@ -35,7 +36,7 @@ class PySAPCARTest(unittest.TestCase):
     test_timestamp = "01 Dec 2015 22:48"
     test_perm_mode = 33204
     test_permissions = "-rw-rw-r--"
-    test_string = "The quick brown fox jumps over the lazy dog"
+    test_string = b"The quick brown fox jumps over the lazy dog"
 
     def setUp(self):
         with open(self.test_filename, "wb") as fd:


### PR DESCRIPTION
Once again ported related unit tests while I was at it. Also created a new module called `six` under `utils` as I had to make some custom general purpose compatibility code and it felt logical to place it somewhere where other modules could access it as well. Solves #27.

I went with "all human string input / output is unicode" approach. This leads to a few odd .decode() here and there, but they all should be commented for clarity.